### PR TITLE
test ledger_getVmLogsByFilter

### DIFF
--- a/test/events.spec.ts
+++ b/test/events.spec.ts
@@ -1,24 +1,23 @@
 import { describe } from "mocha";
 import { expect } from "chai";
 const vite = require('@vite/vuilder');
+import { CommonUtil } from "./utils"
 import config from "./vite.config.json";
 
 let provider: any;
 let deployer: any;
+let a: any;
 
 describe('test events', () => {
-  before(async function() {
+  before(async function () {
     provider = vite.newProvider("http://127.0.0.1:23456");
     deployer = vite.newAccount(config.networks.local.mnemonic, 0, provider);
-  });
-
-  it('test contract', async () => {
     // compile
     const compiledContracts = await vite.compile('events.solpp');
     expect(compiledContracts).to.have.property('A');
 
     // deploy A
-    let a = compiledContracts.A;
+    a = compiledContracts.A;
     a.setDeployer(deployer).setProvider(provider);
     await a.deploy({});
     expect(a.address).to.be.a('string');
@@ -26,10 +25,15 @@ describe('test events', () => {
 
     // call a.test();
     await a.call('test', [], {});
+    await a.call('test', [], {});
+    await a.call('test', [], {});
 
     vite.utils.sleep(1000);
+  });
+
+  it('test contract', async () => {
     // check log
-    let events = await a.getPastEvents('allEvents', {fromHeight: 2, toHeight: 2});
+    let events = await a.getPastEvents('allEvents', { fromHeight: 2, toHeight: 2 });
     // console.log(events);
     expect(events).to.be.an('array').with.length(4); // can't parse anonymous events due to the RPC issue
     expect(events[0].returnValues).to.be.deep.equal({
@@ -61,4 +65,53 @@ describe('test events', () => {
       s: 'hello world'
     });
   });
+
+  var runs = [
+    { id: '1', options: { fromHeight: "0", toHeight: "0", pageIndex: 0, pageSize: 0, expected: 4 } },
+    { id: '2', options: { fromHeight: "0", toHeight: "0", pageIndex: 0, pageSize: 2, expected: 2 } },
+    { id: '3', options: { fromHeight: "0", toHeight: "0", pageIndex: 1, pageSize: 2, expected: 2 } },
+    { id: '4', options: { fromHeight: "0", toHeight: "0", pageIndex: 2, pageSize: 2, expected: 0 } },
+    { id: '5', options: { fromHeight: "1", toHeight: "1", pageIndex: 0, pageSize: 0, expected: 0 } },
+    { id: '6', options: { fromHeight: "0", toHeight: "1", pageIndex: 0, pageSize: 0, expected: 0 } },
+    { id: '7', options: { fromHeight: "0", toHeight: "100", pageIndex: 0, pageSize: 0, expected: 4 } },
+    { id: '8', options: { fromHeight: "100", toHeight: "0", pageIndex: 0, pageSize: 0, expected: 4 } },
+    { id: '9', options: { fromHeight: "1", toHeight: "100", pageIndex: 0, pageSize: 0, expected: 12 } },
+    { id: '10', options: { fromHeight: "1", toHeight: "100", pageIndex: 1, pageSize: 9, expected: 3 } },
+  ]
+
+  runs.forEach(function (run) {
+    it('test ledger_getVmLogsByFilter ' + run.id, async () => {
+      let logs = await getVmLogsByFilterAsync(
+        run.options.fromHeight,
+        run.options.toHeight,
+        run.options.pageIndex,
+        run.options.pageSize
+      )
+      if (run.options.expected > 0) {
+        expect(logs).to.be.an('array').with.length(run.options.expected);
+      } else {
+        expect(logs).to.be.null
+      }
+    });
+  })
+
+  it('test ledger_getVmLogsByFilter error', async () => {
+    const result = await CommonUtil.expectThrowsAsync(() => getVmLogsByFilterAsync("100", "1", 0, 0))
+    expect(result.error.code).to.be.equal(-32002)
+    expect(result.error.message).to.be.equal('to height < from height')
+  });
+
+  function getVmLogsByFilterAsync(fromHeight: string, toHeight: string, pageIndex: number, pageSize: number) {
+    return provider.request("ledger_getVmLogsByFilter",
+      {
+        "addressHeightRange": {
+          [a.address]: {
+            "fromHeight": fromHeight,
+            "toHeight": toHeight
+          }
+        },
+        pageIndex: pageIndex,
+        pageSize: pageSize
+      });
+  }
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai"
+
+export abstract class CommonUtil {
+  public static expectThrowsAsync = async (method: () => Promise<any>, errorMessage?: string) => {
+    let error: any
+    try {
+      await method()
+    }
+    catch (err) {
+      error = err
+    }
+    expect(error).to.not.be.undefined
+    if (errorMessage) {
+      expect(error.message).to.equal(errorMessage)
+    }
+    return error
+  }
+}

--- a/test/vite.node.json
+++ b/test/vite.node.json
@@ -12,7 +12,7 @@
         },
         "nightly": {
             "name": "gvite",
-            "version": "v2.12.0-nightly-202204221713",
+            "version": "v2.11.3-nightly-202207201142",
             "http": "http://127.0.0.1:23456/"
         }
     },


### PR DESCRIPTION
Add test coverage for issue https://github.com/vitelabs/go-vite/issues/579

Run: `npx vuilder test ./test/events.spec.ts --config test/vite.node.json`